### PR TITLE
Adapt icon path removal from core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,4 +1,4 @@
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <parent>
@@ -20,7 +20,7 @@
   <description>Allows users to launch LoadComplete tests from Jenkins</description>
   <version>1.1-SNAPSHOT</version>
   <packaging>hpi</packaging>
-  <url>http://wiki.jenkins-ci.org/display/JENKINS/LoadComplete+Support+Plugin</url>
+  <url>https://plugins.jenkins.io/loadcomplete/</url>
 
   <licenses>
     <license>
@@ -32,7 +32,7 @@
   <repositories>
     <repository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </repository>
   </repositories>
 
@@ -45,16 +45,16 @@
   </dependencies>
 
   <scm>
-    <connection>scm:git:git://github.com/jenkinsci/loadcomplete-plugin.git</connection>
+    <connection>scm:git:https://github.com/jenkinsci/loadcomplete-plugin.git</connection>
     <developerConnection>scm:git:git@github.com:jenkinsci/loadcomplete-plugin.git</developerConnection>
-    <url>http://github.com/jenkinsci/loadcomplete-plugin</url>
+    <url>https://github.com/jenkinsci/loadcomplete-plugin</url>
     <tag>HEAD</tag>
   </scm>
 
   <pluginRepositories>
     <pluginRepository>
       <id>repo.jenkins-ci.org</id>
-      <url>http://repo.jenkins-ci.org/public/</url>
+      <url>https://repo.jenkins-ci.org/public/</url>
     </pluginRepository>
   </pluginRepositories>
 

--- a/src/main/resources/com/smartbear/jenkins/plugins/loadcomplete/LCReportAction/index.jelly
+++ b/src/main/resources/com/smartbear/jenkins/plugins/loadcomplete/LCReportAction/index.jelly
@@ -5,16 +5,16 @@
 
         <l:side-panel>
             <l:tasks>
-                <l:task icon="images/24x24/up.png" href="../.." title="${%BackToSummary}" />
+                <l:task icon="icon-up icon-md" href="../.." title="${%BackToSummary}" />
 
                 <j:set var="nextReport" value="${it.parent.getNextReport(it)}"/>
                 <j:if test="${nextReport != null}">
-                    <l:task icon="images/24x24/next.png" href="../${nextReport.id}" title="${%NextReport}" />
+                    <l:task icon="icon-next icon-md" href="../${nextReport.id}" title="${%NextReport}" />
                 </j:if>
 
                 <j:set var="previousReport" value="${it.parent.getPreviousReport(it)}"/>
                 <j:if test="${previousReport != null}">
-                    <l:task icon="images/24x24/previous.png" href="../${previousReport.id}" title="${%PreviousReport}" />
+                    <l:task icon="icon-previous icon-md" href="../${previousReport.id}" title="${%PreviousReport}" />
                 </j:if>
             </l:tasks>
         </l:side-panel>


### PR DESCRIPTION
The change proposed prepares the plugin for the icon path removal from core in the upcoming LTS line. This change affects plugins not using the icon API or relying on paths. Plugins using the API properly in the first place are unaffected by this change.

Could you trigger a release after merging this PR please, giving people a chance to update the plugin before updating to the next LTS version @Igor-Filin  
Thanks in advance!

Closes #1